### PR TITLE
VOXELFORMAT: scene graph nodes get their own palette

### DIFF
--- a/src/modules/voxelformat/SceneGraphNode.cpp
+++ b/src/modules/voxelformat/SceneGraphNode.cpp
@@ -4,6 +4,7 @@
 
 #include "SceneGraphNode.h"
 #include "core/Log.h"
+#include "voxel/MaterialColor.h"
 #include "voxel/RawVolume.h"
 #include <glm/gtx/transform.hpp>
 #include <glm/ext/scalar_constants.hpp>
@@ -24,6 +25,10 @@ void SceneGraphTransform::print() const {
 	Log::error("matrix\n%.2f %.2f %.2f %.2f\n%.2f %.2f %.2f %.2f\n%.2f %.2f %.2f %.2f\n%.2f %.2f %.2f %.2f",
 			   mat[0][0], mat[0][1], mat[0][2], mat[0][3], mat[1][0], mat[1][1], mat[1][2], mat[1][3], mat[2][0],
 			   mat[2][1], mat[2][2], mat[2][3], mat[3][0], mat[3][1], mat[3][2], mat[3][3]);
+}
+
+voxel::Palette &SceneGraphNode::palette() {
+	return voxel::getPalette(); // TODO:
 }
 
 void SceneGraphTransform::update() {

--- a/src/modules/voxelformat/SceneGraphNode.h
+++ b/src/modules/voxelformat/SceneGraphNode.h
@@ -18,6 +18,7 @@
 namespace voxel {
 
 class RawVolume;
+class Palette;
 
 enum class SceneGraphNodeType {
 	Root,
@@ -119,6 +120,7 @@ public:
 	 * @return voxel::RawVolume - might be @c nullptr
 	 */
 	voxel::RawVolume *volume();
+	voxel::Palette &palette();
 	/**
 	 * @return voxel::Region instance that is invalid when the volume is not set for this instance.
 	 */

--- a/src/modules/voxelrender/RawVolumeRenderer.cpp
+++ b/src/modules/voxelrender/RawVolumeRenderer.cpp
@@ -615,10 +615,10 @@ voxel::Region RawVolumeRenderer::region() const {
 }
 
 voxel::RawVolume* RawVolumeRenderer::setVolume(int idx, voxel::SceneGraphNode& node, bool deleteMesh) {
-	return setVolume(idx, node.volume(), deleteMesh);
+	return setVolume(idx, node.volume(), &node.palette(), deleteMesh);
 }
 
-voxel::RawVolume* RawVolumeRenderer::setVolume(int idx, voxel::RawVolume* volume, bool deleteMesh) {
+voxel::RawVolume* RawVolumeRenderer::setVolume(int idx, voxel::RawVolume* volume, voxel::Palette* palette, bool deleteMesh) {
 	if (idx < 0 || idx >= MAX_VOLUMES) {
 		return nullptr;
 	}
@@ -626,6 +626,7 @@ voxel::RawVolume* RawVolumeRenderer::setVolume(int idx, voxel::RawVolume* volume
 
 	voxel::RawVolume* old = _rawVolume[idx];
 	_rawVolume[idx] = volume;
+	_palette[idx] = palette;
 	if (deleteMesh) {
 		for (auto& i : _meshes) {
 			Meshes& meshes = i.second;

--- a/src/modules/voxelrender/RawVolumeRenderer.h
+++ b/src/modules/voxelrender/RawVolumeRenderer.h
@@ -35,6 +35,7 @@ class Camera;
 
 namespace voxel {
 class SceneGraphNode;
+class Palette;
 }
 
 /**
@@ -56,6 +57,7 @@ protected:
 		bool _gray;
 	};
 	voxel::RawVolume* _rawVolume[MAX_VOLUMES] {};
+	voxel::Palette* _palette[MAX_VOLUMES] {};
 	uint64_t _paletteHash = 0;
 	core::Array<glm::mat4[shader::VoxelInstancedShaderConstants::getMaxInstances()], MAX_VOLUMES> _models;
 	core::Array<glm::vec3[shader::VoxelInstancedShaderConstants::getMaxInstances()], MAX_VOLUMES> _pivots;
@@ -136,7 +138,7 @@ public:
 	 *
 	 * @sa volume()
 	 */
-	voxel::RawVolume* setVolume(int idx, voxel::RawVolume* volume, bool deleteMesh = true);
+	voxel::RawVolume* setVolume(int idx, voxel::RawVolume* volume, voxel::Palette* palette = nullptr, bool deleteMesh = true);
 	voxel::RawVolume* setVolume(int idx, voxel::SceneGraphNode& node, bool deleteMesh = true);
 	bool setModelMatrix(int idx, const glm::mat4& model, const glm::vec3 &pivot, bool reset = true);
 	/**

--- a/src/modules/voxelrender/SceneGraphRenderer.cpp
+++ b/src/modules/voxelrender/SceneGraphRenderer.cpp
@@ -78,7 +78,7 @@ void SceneGraphRenderer::shutdown() {
 void SceneGraphRenderer::clear() {
 	_renderer.clearPendingExtractions();
 	for (int i = 0; i < RawVolumeRenderer::MAX_VOLUMES; ++i) {
-		if (_renderer.setVolume(i, nullptr, true) != nullptr) {
+		if (_renderer.setVolume(i, nullptr, nullptr, true) != nullptr) {
 			_renderer.update(i);
 		}
 	}
@@ -88,7 +88,7 @@ void SceneGraphRenderer::prepare(voxel::SceneGraph &sceneGraph, bool hideInactiv
 	// remove those volumes that are no longer part of the scene graph
 	for (int i = 0; i < RawVolumeRenderer::MAX_VOLUMES; ++i) {
 		if (!sceneGraph.hasNode(i)) {
-			_renderer.setVolume(i, nullptr, true);
+			_renderer.setVolume(i, nullptr, nullptr, true);
 		}
 	}
 
@@ -96,7 +96,7 @@ void SceneGraphRenderer::prepare(voxel::SceneGraph &sceneGraph, bool hideInactiv
 	for (voxel::SceneGraphNode &node : sceneGraph) {
 		voxel::RawVolume *v = _renderer.volume(node.id());
 		if (v != node.volume()) {
-			_renderer.setVolume(node.id(), node.volume(), true);
+			_renderer.setVolume(node.id(), node.volume(), &node.palette(), true);
 			_renderer.extractRegion(node.id(), node.region());
 		}
 		if (_sceneMode) {

--- a/src/tools/voxedit/modules/voxedit-ui/PalettePanel.cpp
+++ b/src/tools/voxedit/modules/voxedit-ui/PalettePanel.cpp
@@ -8,6 +8,7 @@
 #include "voxedit-util/SceneManager.h"
 #include "ui/imgui/IMGUIEx.h"
 #include "ui/imgui/IconsForkAwesome.h"
+#include "voxel/MaterialColor.h"
 #include <glm/gtc/type_ptr.hpp>
 
 #define POPUP_TITLE_LOAD_PALETTE "Select Palette##popuptitle"
@@ -36,13 +37,18 @@ void PalettePanel::reloadAvailablePalettes() {
 }
 
 void PalettePanel::update(const char *title, command::CommandExecutionListener &listener) {
-	voxel::Palette &palette = voxel::getPalette();
+	const int activeNode = sceneMgr().sceneGraph().activeNode();
+	if (activeNode == -1) {
+		return;
+	}
+	voxel::Palette &palette = sceneMgr().sceneGraph().node(activeNode).palette();
 	const int maxPaletteEntries = palette.colorCount;
 	const float height = ImGui::GetContentRegionMax().y;
 	const ImVec2 windowSize(120.0f, height);
 	ImGui::SetNextWindowSize(windowSize, ImGuiCond_FirstUseEver);
 	const int currentSceneHoveredPalIdx = sceneMgr().hitCursorVoxel().getColor();
 	const int currentSelectedPalIdx = sceneMgr().modifier().cursorVoxel().getColor();
+
 	_hasFocus = false;
 	if (ImGui::Begin(title, nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse)) {
 		_hasFocus = ImGui::IsWindowHovered();


### PR DESCRIPTION
Formats like Sandbox, Goxel and others provide own palettes for each node. But currently we can only handle one palette.
Each scene graph node should get its own palette. And access to the global palette must get changed/removed.

As there are also formats that have multiple scene graph node support but only support one global palette, this field should be optional in the node. So maybe a pointer with ownership transfering like for the volume.

# Tasks

- [ ] `PalettePanel` must change on node change
- [x] Palette must get uploaded to material color uniforms on change (see `Palette::hash()`)
- [ ] A lot of references to `voxel::getPalette()` must either be changed to not return a global palette - but one that was registered via (a not yet existing) `voxel::setPalette()` or must get removed by `SceneGraphNode::palette()` calls.
