### PR TITLE
Fixed impossible release date

### DIFF
--- a/contrib/installer/linux/io.github.mgerhardy.vengi.voxedit.metainfo.xml
+++ b/contrib/installer/linux/io.github.mgerhardy.vengi.voxedit.metainfo.xml
@@ -28,7 +28,7 @@
     <category>Utility</category>
   </categories>
   <releases>
-    <release version="v0.0.24" date="2023-93-12" type="stable">
+    <release version="v0.0.24" date="2023-03-12" type="stable">
       <url>https://github.com/mgerhardy/vengi/releases/tag/v0.0.24</url>
     </release>
     <release version="v0.0.23" date="2022-12-17" type="stable">


### PR DESCRIPTION
This seems to have broke https://github.com/flathub/io.github.mgerhardy.vengi.voxedit/pull/4.