### PR TITLE
Update Minecraft Wiki link to new domain after fork

### DIFF
--- a/docs/Formats.md
+++ b/docs/Formats.md
@@ -16,10 +16,10 @@
 | MagicaVoxel                | vox       | X       | X      | X          | X       |            | [spec](https://github.com/ephtracy/voxel-model)                          |
 | MagicaVoxel                | xraw      | X       | X      | X          | X       |            |                                                                          |
 | Minecraft Level            | dat       | X       |        | X          | X       |            |                                                                          |
-| Minecraft Region           | mcr       | X       | X      | X          | X       |            | [spec](https://minecraft.gamepedia.com/Region_file_format)               |
-| Minecraft Schematics       | schematic | X       |        | X          | X       |            | [spec](https://minecraft.fandom.com/wiki/Schematic_file_format)          |
-| Minecraft Schematics       | schem     | X       |        | X          | X       |            | [spec](https://minecraft.fandom.com/wiki/Schematic_file_format)          |
-| Minecraft Schematics       | nbt       | X       |        | X          | X       |            | [spec](https://minecraft.fandom.com/wiki/Schematic_file_format)          |
+| Minecraft Region           | mcr       | X       | X      | X          | X       |            | [spec](https://minecraft.wiki/w/Region_file_format)               |
+| Minecraft Schematics       | schematic | X       |        | X          | X       |            | [spec](https://minecraft.wiki/w/Schematic_file_format)          |
+| Minecraft Schematics       | schem     | X       |        | X          | X       |            | [spec](https://minecraft.wiki/w/Schematic_file_format)          |
+| Minecraft Schematics       | nbt       | X       |        | X          | X       |            | [spec](https://minecraft.wiki/w/Schematic_file_format)          |
 | Minetest                   | mts       | X       |        | X          | X       |            | [spec](https://dev.minetest.net/Minetest_Schematic_File_Format)          |
 | Nick's Voxel Model         | nvm       | X       |        | X          |         |            |                                                                          |
 | Qubicle Binary Tree        | qbt       | X       | X      | X          | X       |            | [spec](https://getqubicle.com/qubicle/documentation/docs/file/qbt/)      |

--- a/src/modules/voxelformat/private/minecraft/DatFormat.h
+++ b/src/modules/voxelformat/private/minecraft/DatFormat.h
@@ -11,7 +11,7 @@ namespace voxelformat {
 /**
  * @brief Minecraft level dat format
  *
- * https://minecraft.fandom.com/wiki/Level.dat
+ * https://minecraft.wiki/w/Level.dat
  *
  * @ingroup Formats
  */

--- a/src/modules/voxelformat/private/minecraft/MCRFormat.cpp
+++ b/src/modules/voxelformat/private/minecraft/MCRFormat.cpp
@@ -144,7 +144,7 @@ bool MCRFormat::readCompressedNBT(scenegraph::SceneGraph &sceneGraph, io::Seekab
 	}
 
 	voxel::RawVolume *volume;
-	// https://minecraft.fandom.com/wiki/Data_version
+	// https://minecraft.wiki/w/Data_version
 	const int32_t dataVersion = root.get("DataVersion").int32();
 	Log::debug("Found data version %i", dataVersion);
 	if (dataVersion >= 2844) {

--- a/src/modules/voxelformat/private/minecraft/MCRFormat.h
+++ b/src/modules/voxelformat/private/minecraft/MCRFormat.h
@@ -60,8 +60,8 @@ using NBTList = core::DynamicArray<NamedBinaryTag>;
  * @endcode
  *
  * @note https://github.com/Voxtric/Minecraft-Level-Ripper/blob/master/WorldConverterV2/Processor.cs
- * @note https://minecraft.fandom.com/wiki/Region_file_format
- * @note https://minecraft.fandom.com/wiki/Chunk_format
+ * @note https://minecraft.wiki/w/Region_file_format
+ * @note https://minecraft.wiki/w/Chunk_format
  * @note https://github.com/UnknownShadow200/ClassiCube/blob/master/src/Formats.c
  *
  * @ingroup Formats

--- a/src/modules/voxelformat/private/minecraft/MinecraftPaletteMap.cpp
+++ b/src/modules/voxelformat/private/minecraft/MinecraftPaletteMap.cpp
@@ -826,8 +826,8 @@ int findPaletteIndex(const core::String &name, int defaultValue) {
 const PaletteMap &getPaletteMap() {
 	// https://gitlab.com/bztsrc/mtsedit/blob/master/etc/Mineclone2.gpl
 	// https://github.com/mcedit/mcedit2/tree/master/src/mceditlib/blocktypes
-	// https://minecraft.gamepedia.com/Java_Edition_data_values
-	// https://minecraft.gamepedia.com/Java_Edition_data_values/Pre-flattening#Block_IDs
+	// https://minecraft.wiki/w/Java_Edition_data_values
+	// https://minecraft.wiki/w/Java_Edition_data_values/Pre-flattening#Block_IDs
 	// https://github.com/erich666/Mineways/blob/c84d1dad8ef9c5d59008b3eabff0161aae9600d6/Win/nbt.cpp#L370
 	#define MCENTRY(name, pal, alpha) {name, {pal, alpha}}
 	static const PaletteMap mcPalette MCCOLORS;

--- a/src/modules/voxelformat/private/minecraft/NamedBinaryTag.h
+++ b/src/modules/voxelformat/private/minecraft/NamedBinaryTag.h
@@ -99,7 +99,7 @@ struct NamedBinaryTagContext {
 };
 
 /**
- * @note https://minecraft.fandom.com/wiki/NBT_format
+ * @note https://minecraft.wiki/w/NBT_format
  * @note https://wiki.vg/NBT
  */
 class NamedBinaryTag {

--- a/src/modules/voxelformat/private/minecraft/SchematicFormat.h
+++ b/src/modules/voxelformat/private/minecraft/SchematicFormat.h
@@ -18,7 +18,7 @@ class NamedBinaryTag;
 }
 
 /**
- * @note https://minecraft.fandom.com/wiki/Schematic_file_format
+ * @note https://minecraft.wiki/w/Schematic_file_format
  * @note https://github.com/SpongePowered/Schematic-Specification/tree/master/versions
  *
  * @ingroup Formats


### PR DESCRIPTION
The Minecraft Wiki maintainers have decided to move away from Fandom. More information can be found here: https://minecraft.wiki/w/Minecraft_Wiki:Moving_from_Fandom. This PR updates all the URLs to the new domain: minecraft.wiki